### PR TITLE
Add more generic support for controllers and icon for Stadia

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "controller-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "controller-tools"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/backend/src/api/bluetooth.rs
+++ b/backend/src/api/bluetooth.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use hidapi::DeviceInfo;
+use std::io::BufRead;
+use std::{fs::File, io, path::Path, process::Command};
+
+/// Get the bluetooth address from the DeviceInfo's hidraw,
+/// e.g. "/sys/class/hidraw/hidraw5/device/uevent".
+/// This file contains the BT address as value of HID_UNIQ
+pub fn get_bluetooth_address(device_info: &DeviceInfo) -> Result<String> {
+    let mut bt_address = "".to_string();
+    let hidraw_path = device_info.path().to_str()?;
+    let prefix = hidraw_path.replace("/dev", "/sys/class/hidraw");
+    let path = [prefix, "device/uevent".to_string()].join("/");
+    let lines = read_lines(path)?;
+    for line in lines {
+        let val = line?;
+        // HID_UNIQ points to the BT address we want to use to grab data from bluetoothctl
+        if val.starts_with("HID_UNIQ") {
+            match val.split("=").skip(1).next() {
+                Some(address) => {
+                    bt_address = address.to_string();
+                }
+                None => {}
+            }
+        }
+    }
+    Ok(bt_address.to_string())
+}
+
+/// For Xbox controllers, "bluetoothctl info <address>" will return info about the controller
+/// including its battery percentage. This important output is:
+/// "Battery Percentage: 0x42 (66)"
+pub fn get_battery_percentage(address: String) -> Result<u8> {
+    let mut percentage = 0;
+    let output = Command::new("bluetoothctl")
+        .args(["info", address.as_str()])
+        .output()?;
+    let content = String::from_utf8_lossy(&output.stdout).to_string();
+    for bt_line in content.lines() {
+        if bt_line.contains("Battery Percentage") {
+            // format is: "Battery Percentage: 0x42 (66)"
+            match bt_line.split(" ").skip(2).next() {
+                Some(percentage_hex) => {
+                    if let Ok(pct) = i64::from_str_radix(&percentage_hex[2..], 16) {
+                        percentage = pct as u8;
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+    Ok(percentage)
+}
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}

--- a/backend/src/api/generic.rs
+++ b/backend/src/api/generic.rs
@@ -1,0 +1,59 @@
+use super::bluetooth::{get_battery_percentage, get_bluetooth_address};
+use super::nintendo::VENDOR_ID_NINTENDO;
+use super::playstation::DS_VENDOR_ID;
+use super::xbox::MS_VENDOR_ID;
+
+use anyhow::Result;
+use hidapi::{DeviceInfo, HidApi};
+use log::error;
+
+use super::Controller;
+
+const VALVE_VENDOR_ID: u16 = 0x28de;
+const FOCALTECH_VENDOR_ID: u16 = 0x2808; // touchpad?
+pub const IGNORED_VENDORS: [u16; 5] = [
+    VALVE_VENDOR_ID,
+    FOCALTECH_VENDOR_ID,
+    VENDOR_ID_NINTENDO,
+    DS_VENDOR_ID,
+    MS_VENDOR_ID,
+];
+
+pub fn get_controller_data(device_info: &DeviceInfo, _hidapi: &HidApi) -> Result<Controller> {
+    let bluetooth = device_info.interface_number() == -1;
+    // let device = device_info.open_device(hidapi)?;
+
+    let capacity: u8 = match get_bluetooth_address(device_info) {
+        Ok(address) => match get_battery_percentage(address) {
+            Ok(percentage) => percentage,
+            Err(err) => {
+                error!("get_battery_percentage failed because {}", err);
+                0
+            }
+        },
+        Err(err) => {
+            error!("get_bluetooth_address failed because {}", err);
+            0
+        }
+    };
+
+    let mut name = device_info
+        .product_string()
+        .unwrap_or("Unknown Controller")
+        .to_string();
+    if name.starts_with("Stadia") {
+        // product string is e.g. Stadia-CG9S-4e9f, this would be better
+        name = "Stadia Controller".to_string();
+    }
+
+    let controller = Controller {
+        name,
+        product_id: device_info.product_id(),
+        vendor_id: device_info.vendor_id(),
+        capacity,
+        status: "unknown".to_string(),
+        bluetooth,
+    };
+
+    Ok(controller)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ControllerTools",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The missing game controller menu. Displays the current battery % and charging status",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+rm -rf build
+mkdir -p build/bin
+
+npm run build
+cp -r dist build/
+
+cargo build --release --manifest-path backend/Cargo.toml
+cp ./backend/target/release/controller-tools build/bin/backend
+
+cp package.json build/package.json
+cp plugin.json build/plugin.json
+cp main.py build/main.py
+cp README.md build/README.md
+cp LICENSE build/LICENSE
+
+mv build ControllerTools
+VERSION=$(cat package.json| jq -r '.version')
+rm -f controller-tools-$VERSION.zip
+zip -r controller-tools-$VERSION.zip ControllerTools/*
+mv ControllerTools build

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "decky-frontend-lib";
 import { useEffect, useState, VFC } from "react";
 import { BiBluetooth, BiUsb } from "react-icons/bi";
+import { SiStadia } from "react-icons/si";
 import { RiSwitchLine } from "react-icons/ri";
 import { FaBatteryEmpty, FaBatteryFull, FaBatteryQuarter, FaBatteryHalf, FaBatteryThreeQuarters, FaPlaystation, FaXbox } from "react-icons/fa";
 import { BsController, BsBatteryCharging } from "react-icons/bs";
@@ -43,6 +44,8 @@ function getVendorIcon(controller: Controller): JSX.Element {
       return <RiSwitchLine />;
     case 1118:
       return <FaXbox />
+    case 6353: // 0x18D1 = Google
+      return <SiStadia />
     default:
       return <BsController />;
   }


### PR DESCRIPTION
This should take care of duplicate controllers and filters out some devices listed by hidapi like the steam controllers (USB) and the touchpad. It might bubble up some unexpected devices though but we can filter those out maybe as needed. But at least with this we can display controllers more generically and get Stadia support working