### PR TITLE
Fixes a bug when multiple DS or DS4 controllers are plugged in

### DIFF
--- a/backend/src/api/playstation.rs
+++ b/backend/src/api/playstation.rs
@@ -141,7 +141,7 @@ pub fn parse_dualshock_controller_data(
     hidapi: &HidApi,
 ) -> Result<Controller> {
     let bluetooth = device_info.interface_number() == -1;
-    let device = hidapi.open(device_info.vendor_id(), device_info.product_id())?;
+    let device = device_info.open_device(hidapi)?;
     let mut controller = Controller {
         name: "DualShock 4".to_string(),
         product_id: device_info.product_id(),
@@ -189,7 +189,7 @@ pub fn parse_dualsense_controller_data(
     hidapi: &HidApi,
 ) -> Result<Controller> {
     let bluetooth = device_info.interface_number() == -1;
-    let device = hidapi.open(device_info.vendor_id(), device_info.product_id())?;
+    let device = device_info.open_device(hidapi)?;
 
     // Read data from device_info
     let mut buf = [0u8; DS_INPUT_REPORT_BT_SIZE];


### PR DESCRIPTION
When calling `hidapi.open(device_info.vendor_id(), device_info.product_id())?;`when multiple devices with the same vendor/product ID are connected, hidapi will always return the first one.

The correct way to get the device is by calling `device_info.open_device(hidapi)?;`. This will use the device path or fallback to using the serial.

closes #15 