### PR TITLE
Fix alert bug with multiple product_id with a refactor

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -22,11 +22,7 @@ pub fn controllers() -> Result<Vec<Controller>> {
 
     // If in debug mode, check if there is a fake controller in /tmp/fake_controller.json
     if cfg!(debug_assertions) {
-        if let Ok(file) = std::fs::File::open("/tmp/fake_controller.json") {
-            let controller: Controller = serde_json::from_reader(file)?;
-            debug!("Found fake controller: {:?}", controller);
-            controllers.push(controller);
-        }
+        parse_fake_controller(&mut controllers);
     }
 
     // HidApi will return 2 copies of the device when the Nintendo Pro Controller is connected via USB.
@@ -145,4 +141,22 @@ pub fn controllers() -> Result<Vec<Controller>> {
     }
 
     Ok(controllers)
+}
+
+fn parse_fake_controller(controllers: &mut Vec<Controller>) {
+    if let Ok(file) = std::fs::File::open("/tmp/fake_controller.json") {
+        let controller = match serde_json::from_reader(file) {
+            Ok(controller) => {
+                debug!("Loaded fake controller: {:?}", controller);
+                Some(controller)
+            }
+            Err(e) => {
+                debug!("Error parsing fake controller: {}", e);
+                None
+            }
+        };
+        if let Some(controller) = controller {
+            controllers.push(controller);
+        }
+    }
 }

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -8,7 +8,7 @@ use hidapi::HidApi;
 use log::debug;
 use udev::Enumerator;
 
-use crate::controller::Controller;
+use crate::controller::{Controller, Status};
 
 pub async fn controllers_async() -> Result<Vec<Controller>> {
     // Spawn a tokio blocking task because `get_controllers()` is a blocking API
@@ -133,7 +133,7 @@ pub fn controllers() -> Result<Vec<Controller>> {
     enumerator.match_subsystem("usb")?;
     for device in enumerator.scan_devices()? {
         let mut controller =
-            Controller::from_udev(&device, "Unknown Controller", 0, "unknown", false);
+            Controller::from_udev(&device, "Unknown Controller", 0, Status::Unknown, false);
         if xbox::is_xbox_controller(controller.vendor_id) {
             xbox::update_xbox_controller(&mut controller, false);
             controllers.push(controller);

--- a/backend/src/api/bluetooth.rs
+++ b/backend/src/api/bluetooth.rs
@@ -36,13 +36,10 @@ pub fn get_battery_percentage(address: String) -> Result<u8> {
     for bt_line in content.lines() {
         if bt_line.contains("Battery Percentage") {
             // format is: "Battery Percentage: 0x42 (66)"
-            match bt_line.split(' ').nth(2) {
-                Some(percentage_hex) => {
-                    if let Ok(pct) = i64::from_str_radix(&percentage_hex[2..], 16) {
-                        percentage = pct as u8;
-                    }
+            if let Some(percentage_hex) = bt_line.split(' ').nth(2) {
+                if let Ok(pct) = i64::from_str_radix(&percentage_hex[2..], 16) {
+                    percentage = pct as u8;
                 }
-                None => {}
             }
         }
     }

--- a/backend/src/api/bluetooth.rs
+++ b/backend/src/api/bluetooth.rs
@@ -16,15 +16,12 @@ pub fn get_bluetooth_address(device_info: &DeviceInfo) -> Result<String> {
         let val = line?;
         // HID_UNIQ points to the BT address we want to use to grab data from bluetoothctl
         if val.starts_with("HID_UNIQ") {
-            match val.split("=").skip(1).next() {
-                Some(address) => {
-                    bt_address = address.to_string();
-                }
-                None => {}
+            if let Some(address) = val.split('=').nth(1) {
+                bt_address = address.to_string();
             }
         }
     }
-    Ok(bt_address.to_string())
+    Ok(bt_address)
 }
 
 /// For Xbox controllers, "bluetoothctl info <address>" will return info about the controller
@@ -39,7 +36,7 @@ pub fn get_battery_percentage(address: String) -> Result<u8> {
     for bt_line in content.lines() {
         if bt_line.contains("Battery Percentage") {
             // format is: "Battery Percentage: 0x42 (66)"
-            match bt_line.split(" ").skip(2).next() {
+            match bt_line.split(' ').nth(2) {
                 Some(percentage_hex) => {
                     if let Ok(pct) = i64::from_str_radix(&percentage_hex[2..], 16) {
                         percentage = pct as u8;

--- a/backend/src/api/generic.rs
+++ b/backend/src/api/generic.rs
@@ -1,3 +1,5 @@
+use crate::controller::Controller;
+
 use super::bluetooth::{get_battery_percentage, get_bluetooth_address};
 use super::nintendo::VENDOR_ID_NINTENDO;
 use super::playstation::DS_VENDOR_ID;
@@ -6,8 +8,6 @@ use super::xbox::MS_VENDOR_ID;
 use anyhow::Result;
 use hidapi::{DeviceInfo, HidApi};
 use log::error;
-
-use super::Controller;
 
 const VALVE_VENDOR_ID: u16 = 0x28de;
 const FOCALTECH_VENDOR_ID: u16 = 0x2808; // touchpad?
@@ -20,9 +20,6 @@ pub const IGNORED_VENDORS: [u16; 5] = [
 ];
 
 pub fn get_controller_data(device_info: &DeviceInfo, _hidapi: &HidApi) -> Result<Controller> {
-    let bluetooth = device_info.interface_number() == -1;
-    // let device = device_info.open_device(hidapi)?;
-
     let capacity: u8 = match get_bluetooth_address(device_info) {
         Ok(address) => match get_battery_percentage(address) {
             Ok(percentage) => percentage,
@@ -37,23 +34,12 @@ pub fn get_controller_data(device_info: &DeviceInfo, _hidapi: &HidApi) -> Result
         }
     };
 
-    let mut name = device_info
-        .product_string()
-        .unwrap_or("Unknown Controller")
-        .to_string();
+    let mut name = device_info.product_string().unwrap_or("Unknown Controller");
     if name.starts_with("Stadia") {
         // product string is e.g. Stadia-CG9S-4e9f, this would be better
-        name = "Stadia Controller".to_string();
+        name = "Stadia Controller";
     }
 
-    let controller = Controller {
-        name,
-        product_id: device_info.product_id(),
-        vendor_id: device_info.vendor_id(),
-        capacity,
-        status: "unknown".to_string(),
-        bluetooth,
-    };
-
+    let controller = Controller::from_hidapi(device_info, name, capacity, "unknown");
     Ok(controller)
 }

--- a/backend/src/api/generic.rs
+++ b/backend/src/api/generic.rs
@@ -1,4 +1,4 @@
-use crate::controller::Controller;
+use crate::controller::{Controller, Status};
 
 use super::bluetooth::{get_battery_percentage, get_bluetooth_address};
 use super::nintendo::VENDOR_ID_NINTENDO;
@@ -40,6 +40,6 @@ pub fn get_controller_data(device_info: &DeviceInfo, _hidapi: &HidApi) -> Result
         name = "Stadia Controller";
     }
 
-    let controller = Controller::from_hidapi(device_info, name, capacity, "unknown");
+    let controller = Controller::from_hidapi(device_info, name, capacity, Status::Unknown);
     Ok(controller)
 }

--- a/backend/src/api/nintendo.rs
+++ b/backend/src/api/nintendo.rs
@@ -3,6 +3,8 @@ use hidapi::{DeviceInfo, HidApi};
 use log::{debug, error};
 use serde::Deserialize;
 
+use crate::controller::Status;
+
 use super::Controller;
 
 pub const VENDOR_ID_NINTENDO: u16 = 0x057e;
@@ -26,7 +28,7 @@ struct InputReport {
 }
 
 pub fn parse_pro_controller_data(device_info: &DeviceInfo, hidapi: &HidApi) -> Result<Controller> {
-    let mut controller = Controller::from_hidapi(device_info, "Pro Controller", 0, "unknown");
+    let mut controller = Controller::from_hidapi(device_info, "Pro Controller", 0, Status::Unknown);
 
     let device = device_info.open_device(hidapi)?;
     let mut buf = [0u8; INPUT_REPORT_SIZE];
@@ -44,9 +46,9 @@ pub fn parse_pro_controller_data(device_info: &DeviceInfo, hidapi: &HidApi) -> R
     let battery_charging = tmp & BIT!(4) != 0;
     let tmp = tmp >> 5;
     controller.status = if battery_charging {
-        "charging".to_string()
+        Status::Charging
     } else {
-        "discharging".to_string()
+        Status::Discharging
     };
     match tmp {
         0 => controller.capacity = 5,

--- a/backend/src/api/playstation.rs
+++ b/backend/src/api/playstation.rs
@@ -140,26 +140,21 @@ pub fn parse_dualshock_controller_data(
     device_info: &DeviceInfo,
     hidapi: &HidApi,
 ) -> Result<Controller> {
-    let bluetooth = device_info.interface_number() == -1;
     let device = device_info.open_device(hidapi)?;
-    let mut controller = Controller {
-        name: "DualShock 4".to_string(),
-        product_id: device_info.product_id(),
-        vendor_id: device_info.vendor_id(),
-        capacity: 0,
-        status: "unknown".to_string(),
-        bluetooth,
-    };
+    let mut controller = Controller::from_hidapi(device_info, "DualShock 4", 0, "unknown");
     let mut buf = vec![0u8; DS4_INPUT_REPORT_BT_SIZE];
     let res = device.read(&mut buf[..])?;
     let mut battery_data: u8 = 0;
     let mut cable_state: u8 = 0;
-    if !bluetooth && buf[0] == DS4_INPUT_REPORT_USB && res == DS4_INPUT_REPORT_USB_SIZE {
+    if !controller.bluetooth && buf[0] == DS4_INPUT_REPORT_USB && res == DS4_INPUT_REPORT_USB_SIZE {
         let usb_report: Dualshock4InputReportUSB = bincode::deserialize(&buf)?;
         let ds4_report: DualShock4InputReportCommon = usb_report.common;
         battery_data = ds4_report.status[0] & DS4_STATUS_BATTERY_CAPACITY;
         cable_state = ds4_report.status[0] & DS4_STATUS0_CABLE_STATE;
-    } else if bluetooth && buf[0] == DS4_INPUT_REPORT_BT && res == DS4_INPUT_REPORT_BT_SIZE {
+    } else if controller.bluetooth
+        && buf[0] == DS4_INPUT_REPORT_BT
+        && res == DS4_INPUT_REPORT_BT_SIZE
+    {
         let bt_report: Dualshock4InputReportBT = bincode::deserialize(&buf)?;
         let ds4_report: DualShock4InputReportCommon = bt_report.common;
         battery_data = ds4_report.status[0] & DS4_STATUS_BATTERY_CAPACITY;
@@ -188,25 +183,18 @@ pub fn parse_dualsense_controller_data(
     device_info: &DeviceInfo,
     hidapi: &HidApi,
 ) -> Result<Controller> {
-    let bluetooth = device_info.interface_number() == -1;
+    let mut controller = Controller::from_hidapi(device_info, "DualSense", 0, "unknown");
     let device = device_info.open_device(hidapi)?;
 
     // Read data from device_info
     let mut buf = [0u8; DS_INPUT_REPORT_BT_SIZE];
     let res = device.read(&mut buf[..])?;
-    let mut controller = Controller {
-        name: "DualSense".to_string(),
-        product_id: device_info.product_id(),
-        vendor_id: device_info.vendor_id(),
-        capacity: 0,
-        status: "unknown".to_string(),
-        bluetooth,
-    };
 
     let ds_report: DualSenseInputReport;
-    if !bluetooth && buf[0] == DS_INPUT_REPORT_USB && res == DS_INPUT_REPORT_USB_SIZE {
+    if !controller.bluetooth && buf[0] == DS_INPUT_REPORT_USB && res == DS_INPUT_REPORT_USB_SIZE {
         ds_report = bincode::deserialize(&buf[1..])?;
-    } else if bluetooth && buf[0] == DS_INPUT_REPORT_BT && res == DS_INPUT_REPORT_BT_SIZE {
+    } else if controller.bluetooth && buf[0] == DS_INPUT_REPORT_BT && res == DS_INPUT_REPORT_BT_SIZE
+    {
         ds_report = bincode::deserialize(&buf[2..])?;
     } else {
         error!("Unhandled report ID: {}", buf[0]);

--- a/backend/src/api/xbox.rs
+++ b/backend/src/api/xbox.rs
@@ -6,12 +6,10 @@ use log::error;
 use super::Controller;
 
 pub const MS_VENDOR_ID: u16 = 0x045e;
-pub const MS_VENDOR_ID_STR: &str = "045e";
 
 // Xbox One S controller
-pub const XBOX_CONTROLLER_USB_PRODUCT_ID: u16 = 0x02ea; // 746
-pub const XBOX_CONTROLLER_USB_PRODUCT_ID_STR: &str = "02ea"; // 746
-pub const XBOX_CONTROLLER_PRODUCT_ID: u16 = 0x02df; // 765
+pub const XBOX_ONE_S_CONTROLLER_USB_PRODUCT_ID: u16 = 0x02ea; // 746
+pub const XBOX_ONE_S_CONTROLLER_BT_PRODUCT_ID: u16 = 0x02df; // 765
 
 // after upgrade to the latest firmware (same as Series X/S),
 // the One S controller changed product ID!
@@ -19,42 +17,40 @@ pub const XBOX_ONE_S_LATEST_FW_PRODUCT_ID: u16 = 0x0b20; // 2848
 
 // Xbox Wireless Controller (model 1914)
 pub const XBOX_WIRELESS_CONTROLLER_USB_PRODUCT_ID: u16 = 0x0b12; // 2834
-pub const XBOX_WIRELESS_CONTROLLER_USB_PRODUCT_ID_STR: &str = "0b12"; // 2834
 pub const XBOX_WIRELESS_CONTROLLER_BT_PRODUCT_ID: u16 = 0x0b13; // 2835
 
 // pub const XBOX_ONE_REPORT_BT_SIZE: usize = 64;
 
-pub fn get_xbox_controller(product_id: u16, bluetooth: bool) -> Result<Controller> {
-    let controller = Controller {
-        name: if product_id == XBOX_WIRELESS_CONTROLLER_USB_PRODUCT_ID
-            || product_id == XBOX_WIRELESS_CONTROLLER_BT_PRODUCT_ID
-        {
-            "Xbox Series X/S".to_string()
-        } else {
-            "Xbox One S".to_string()
-        },
-        product_id,
-        vendor_id: MS_VENDOR_ID,
-        capacity: if bluetooth { 0 } else { 100 }, // for now for USB, "fake" it and set capacity to 100 as charging
-        status: if bluetooth {
-            "unknown".to_string()
-        } else {
-            // for now for USB, "fake" it and set status to charging since it's plugged in
-            "charging".to_string()
-        },
-        bluetooth,
-    };
+fn get_xbox_controller_name(product_id: u16) -> &'static str {
+    match product_id {
+        XBOX_ONE_S_CONTROLLER_USB_PRODUCT_ID => "Xbox One S",
+        XBOX_ONE_S_CONTROLLER_BT_PRODUCT_ID => "Xbox One S",
+        XBOX_ONE_S_LATEST_FW_PRODUCT_ID => "Xbox One S",
+        XBOX_WIRELESS_CONTROLLER_USB_PRODUCT_ID => "Xbox Series X/S",
+        XBOX_WIRELESS_CONTROLLER_BT_PRODUCT_ID => "Xbox Series X/S",
+        _ => "Xbox Unknown",
+    }
+}
 
-    Ok(controller)
+pub fn is_xbox_controller(vendor_id: u16) -> bool {
+    vendor_id == MS_VENDOR_ID
+}
+
+pub fn update_xbox_controller(controller: &mut Controller, bluetooth: bool) {
+    controller.name = get_xbox_controller_name(controller.product_id).to_string();
+    controller.capacity = if bluetooth { 0 } else { 100 }; // for now for USB, "fake" it and set capacity to 100 as charging
+    controller.status = if bluetooth {
+        "unknown".to_string()
+    } else {
+        // for now for USB, "fake" it and set status to charging since it's plugged in
+        "charging".to_string()
+    };
 }
 
 pub fn parse_xbox_controller_data(
     device_info: &DeviceInfo,
     _hidapi: &HidApi,
 ) -> Result<Controller> {
-    let bluetooth = device_info.interface_number() == -1;
-    // let device = device_info.open_device(hidapi)?;
-
     let capacity: u8 = match get_bluetooth_address(device_info) {
         Ok(address) => match get_battery_percentage(address) {
             Ok(percentage) => percentage,
@@ -68,21 +64,8 @@ pub fn parse_xbox_controller_data(
             0
         }
     };
+    let name = get_xbox_controller_name(device_info.product_id());
 
-    let controller = Controller {
-        name: if device_info.product_id() == XBOX_WIRELESS_CONTROLLER_USB_PRODUCT_ID
-            || device_info.product_id() == XBOX_WIRELESS_CONTROLLER_BT_PRODUCT_ID
-        {
-            "Xbox Series X/S".to_string()
-        } else {
-            "Xbox One S".to_string()
-        },
-        product_id: device_info.product_id(),
-        vendor_id: device_info.vendor_id(),
-        capacity,
-        status: "unknown".to_string(),
-        bluetooth,
-    };
-
+    let controller = Controller::from_hidapi(device_info, name, capacity, "unknown");
     Ok(controller)
 }

--- a/backend/src/api/xbox.rs
+++ b/backend/src/api/xbox.rs
@@ -1,3 +1,5 @@
+use crate::controller::Status;
+
 use super::bluetooth::{get_battery_percentage, get_bluetooth_address};
 use anyhow::Result;
 use hidapi::{DeviceInfo, HidApi};
@@ -40,10 +42,10 @@ pub fn update_xbox_controller(controller: &mut Controller, bluetooth: bool) {
     controller.name = get_xbox_controller_name(controller.product_id).to_string();
     controller.capacity = if bluetooth { 0 } else { 100 }; // for now for USB, "fake" it and set capacity to 100 as charging
     controller.status = if bluetooth {
-        "unknown".to_string()
+        Status::Unknown
     } else {
         // for now for USB, "fake" it and set status to charging since it's plugged in
-        "charging".to_string()
+        Status::Charging
     };
 }
 
@@ -66,6 +68,6 @@ pub fn parse_xbox_controller_data(
     };
     let name = get_xbox_controller_name(device_info.product_id());
 
-    let controller = Controller::from_hidapi(device_info, name, capacity, "unknown");
+    let controller = Controller::from_hidapi(device_info, name, capacity, Status::Unknown);
     Ok(controller)
 }

--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -110,7 +110,7 @@ fn hex_os_str_to_u16(hex_os_str: &OsStr) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use super::hex_os_str_to_u16;
+    use super::{hex_os_str_to_u16, Controller};
     use std::ffi::OsStr;
 
     #[test]
@@ -131,6 +131,26 @@ mod tests {
             serialized,
             r#"{"name":"Test Controller","productId":1118,"vendorId":746,"capacity":0,"status":"disconnected","bluetooth":false}"#
         );
+    }
+
+    #[test]
+    fn test_id() {
+        let mut controller = Controller {
+            name: "Test Controller".to_string(),
+            product_id: 0x045e,
+            vendor_id: 0x02ea,
+            capacity: 0,
+            status: "disconnected".to_string(),
+            bluetooth: false,
+            device_path: Some("/dev/input/js0".to_string()),
+            serial_number: Some("1234567890".to_string()),
+        };
+
+        assert_eq!(controller.id(), "/dev/input/js0");
+        controller.device_path = None;
+        assert_eq!(controller.id(), "1234567890");
+        controller.serial_number = None;
+        assert_eq!(controller.id(), "746:1118");
     }
 
     #[test]

--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -28,7 +28,9 @@ impl Controller {
         status: &str,
         bluetooth: bool,
     ) -> Self {
-        let serial_number = device.property_value("ID_SERIAL_SHORT").map(|serial_number| serial_number.to_string_lossy().to_string());
+        let serial_number = device
+            .property_value("ID_SERIAL_SHORT")
+            .map(|serial_number| serial_number.to_string_lossy().to_string());
         let device_path = if device.devpath().is_empty() {
             None
         } else {
@@ -57,7 +59,10 @@ impl Controller {
     }
 
     pub fn from_hidapi(device_info: &DeviceInfo, name: &str, capacity: u8, status: &str) -> Self {
-        let serial_number = device_info.serial_number().map(|serial_number| serial_number.to_string());
+        let serial_number = device_info
+            .serial_number()
+            .filter(|serial_number| !serial_number.is_empty())
+            .map(|serial_number| serial_number.to_string());
         let bluetooth = device_info.interface_number() == -1;
         let device_path_bytes = device_info.path().to_bytes();
         let device_path = if device_path_bytes.is_empty() {

--- a/backend/src/controller.rs
+++ b/backend/src/controller.rs
@@ -1,0 +1,147 @@
+use std::ffi::OsStr;
+
+use hidapi::DeviceInfo;
+use log::error;
+use serde::{Deserialize, Serialize};
+use udev::Device;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Controller {
+    pub name: String,
+    pub product_id: u16,
+    pub vendor_id: u16,
+    pub capacity: u8,
+    pub status: String,
+    pub bluetooth: bool,
+    #[serde(skip_serializing)]
+    pub serial_number: Option<String>,
+    #[serde(skip_serializing)]
+    pub device_path: Option<String>,
+}
+
+impl Controller {
+    pub fn from_udev(
+        device: &Device,
+        name: &str,
+        capacity: u8,
+        status: &str,
+        bluetooth: bool,
+    ) -> Self {
+        let serial_number = device.property_value("ID_SERIAL_SHORT").map(|serial_number| serial_number.to_string_lossy().to_string());
+        let device_path = if device.devpath().is_empty() {
+            None
+        } else {
+            Some(device.devpath().to_string_lossy().to_string())
+        };
+
+        let vendor_id: u16 = device
+            .property_value("ID_VENDOR_ID")
+            .map(hex_os_str_to_u16)
+            .unwrap_or(0);
+        let product_id: u16 = device
+            .property_value("ID_MODEL_ID")
+            .map(hex_os_str_to_u16)
+            .unwrap_or(0);
+
+        Self {
+            name: name.to_string(),
+            vendor_id,
+            product_id,
+            capacity,
+            status: status.to_string(),
+            bluetooth,
+            serial_number,
+            device_path,
+        }
+    }
+
+    pub fn from_hidapi(device_info: &DeviceInfo, name: &str, capacity: u8, status: &str) -> Self {
+        let serial_number = device_info.serial_number().map(|serial_number| serial_number.to_string());
+        let bluetooth = device_info.interface_number() == -1;
+        let device_path_bytes = device_info.path().to_bytes();
+        let device_path = if device_path_bytes.is_empty() {
+            None
+        } else {
+            Some(String::from_utf8_lossy(device_path_bytes).to_string())
+        };
+
+        Self {
+            name: name.to_string(),
+            product_id: device_info.product_id(),
+            vendor_id: device_info.vendor_id(),
+            capacity,
+            status: status.to_string(),
+            bluetooth,
+            serial_number,
+            device_path,
+        }
+    }
+
+    pub fn id(&self) -> String {
+        // Use the device path if it's available, otherwise use the serial number.
+        // If neither are available, use a combination of the vendor and product IDs.
+        match &self.device_path {
+            Some(device_path) => device_path.to_string(),
+            None => match &self.serial_number {
+                Some(serial_number) => serial_number.to_string(),
+                None => format!("{}:{}", self.vendor_id, self.product_id),
+            },
+        }
+    }
+}
+
+fn hex_os_str_to_u16(hex_os_str: &OsStr) -> u16 {
+    let hex_str = hex_os_str.to_string_lossy();
+
+    match u16::from_str_radix(&hex_str, 16) {
+        Ok(num) => num,
+        Err(err) => {
+            error!("Failed to parse hex string: {}", err);
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex_os_str_to_u16;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn test_json_serialization() {
+        // Verify that serde doesn't serialize the serial_number and device_path fields
+        let controller = super::Controller {
+            name: "Test Controller".to_string(),
+            product_id: 0x045e,
+            vendor_id: 0x02ea,
+            capacity: 0,
+            status: "disconnected".to_string(),
+            bluetooth: false,
+            serial_number: Some("1234567890".to_string()),
+            device_path: Some("/dev/input/js0".to_string()),
+        };
+        let serialized = serde_json::to_string(&controller).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"name":"Test Controller","productId":1118,"vendorId":746,"capacity":0,"status":"disconnected","bluetooth":false}"#
+        );
+    }
+
+    #[test]
+    fn test_hex_os_str_to_u16() {
+        let os_str = OsStr::new("045e");
+        let parsed_num = hex_os_str_to_u16(os_str);
+        assert_eq!(0x045e, parsed_num);
+        assert_eq!(1118, parsed_num);
+
+        let os_str = OsStr::new("02ea");
+        let parsed_num = hex_os_str_to_u16(os_str);
+        assert_eq!(0x02ea, parsed_num);
+        assert_eq!(746, parsed_num);
+
+        let os_str = OsStr::new("foobar");
+        let parsed_num = hex_os_str_to_u16(os_str);
+        assert_eq!(0, parsed_num);
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,10 +1,9 @@
 mod api;
+mod controller;
 mod settings;
 mod ws;
 
 use std::{fs::File, net::SocketAddr, sync::Arc};
-
-use api::Controller;
 
 use axum::{
     extract::State,
@@ -13,6 +12,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use controller::Controller;
 use log::info;
 use settings::Settings;
 use simplelog::{
@@ -35,7 +35,7 @@ async fn main() {
         Ok(_) => "/home/deck/homebrew/settings/controller-tools.json",
         Err(_) => "/tmp/controller-tools.json",
     };
-    let settings_service = SettingsService::new(&settings_location).await.unwrap();
+    let settings_service = SettingsService::new(settings_location).await.unwrap();
 
     let level_filter = match settings_service.get_settings().await.debug {
         true => LevelFilter::Debug,
@@ -56,9 +56,7 @@ async fn main() {
     ])
     .unwrap();
 
-    let app_state = Arc::new(AppState {
-        settings_service: settings_service,
-    });
+    let app_state = Arc::new(AppState { settings_service });
 
     let app = Router::new()
         .route("/controllers", get(controllers_json))

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -87,6 +87,7 @@ impl SettingsService {
     }
 }
 
+#[cfg(test)]
 mod test {
 
     #[tokio::test]

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -107,12 +107,12 @@ mod test {
         assert_eq!(settings.notifications, true);
         settings.notifications = false;
         settings_service.set_settings(settings).await?;
-        assert_eq!(settings_service.get_settings().await.notifications, false);
+        assert!(!settings_service.get_settings().await.notifications);
 
         // Read it again
         let settings_service = SettingsService::new(&file_path).await?;
         let settings = settings_service.get_settings().await;
-        assert_eq!(settings.notifications, false);
+        assert!(!settings.notifications);
 
         // Delete the config file
         tokio::fs::remove_file(file_path).await?;

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -72,7 +72,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
     // a controller is low on battery
     let mut send_task = tokio::spawn(async move {
         // HashMap to store last alert timestamps for each controller
-        let mut last_alerts: HashMap<(u16, u16), u64> = HashMap::new();
+        let mut last_alerts: HashMap<String, u64> = HashMap::new();
         let mut cnt = 0;
 
         loop {
@@ -105,12 +105,9 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
                         .unwrap()
                         .as_secs();
 
-                    let first_alert =
-                        !last_alerts.contains_key(&(controller.vendor_id, controller.product_id));
+                    let first_alert = !last_alerts.contains_key(&controller.id());
 
-                    let last_alert = last_alerts
-                        .entry((controller.vendor_id, controller.product_id))
-                        .or_insert(now);
+                    let last_alert = last_alerts.entry(controller.id()).or_insert(now);
 
                     let last_alert_secs_ago = now - *last_alert;
                     debug!(

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -94,7 +94,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
             };
 
             for controller in controllers {
-                let low_battery = controller.capacity < 20 && controller.status == "discharging";
+                let low_battery = controller.capacity < 20 && controller.is_discharging();
                 debug!(
                     "Controller {} is low battery: {}",
                     controller.name, low_battery


### PR DESCRIPTION
We need a unique identifier for each controller for alerts. Previously we used the vendor/product ID tuple, but that would be a problem when someone connects multiple controllers with the same tuple. The ID is used in alerts to control how often we send a low-battery warning. To accomplish this, I made a new `id()` method that uses the device path if found, otherwise falls back to the serial number, or if both are missing, uses the vendor/product ID tuple.

I moved most of our controller logic to `controller.rs` and created two constructor methods, one for hidapi and another for udev. These constructors will extract the device path and serial number for each API, and set other fields where we were duplicating logic for each vendor module (like detecting Bluetooth).

Finally, I ran `cargo clippy` (Rust linter) and cleaned up a bunch of the stuff it detected. It also suggests more idiomatic ways to do things.