### PR TITLE
Implement support for Sony DualShock 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Steam Deck game controller plugin for [Decky Loader](https://github.com/SteamDec
 
 ## Supported Controllers
 * PlayStation DualSense
+* Playstation DualShock 3
 * Playstation DualShock 4
 * Nintendo Switch Pro Controller
 * Xbox Series X|S Controller


### PR DESCRIPTION
Implement support for the Sony DualShock 3 controller.

This implementation was based on the [linux driver for this controller](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-sony.c#L796) and tested manually using both Bluetooth connection and USB cable.

The DS3 reports battery capacity in a odd way. It actually only reports 7 possible values: 0, 1, 25, 50, 75, 100% battery capacity, charging-not-full or charging-full. So I had to choose which value of battery capacity when it reports charging-not-full. I opted for 75% so the user wouldn't think the battery is full when it is not. But this leads to a funny situation:
- Controller is connected via Bluetooth reporting 100% battery
- User connects the controller via cable
- Now we are going to report battery as 75%. It seems like the controller just lost battery capacity.
Anyway, this is just a minor inconvenience, but it is confusing.

I tried to follow all code conventions, but I may have failed.

Please point out errors and improvements I could make to the code.

All tests were done using a DualShock 3 model CECHZC2U. I can adapt the code to other similar models if needed, however, I don't have other DS3 controllers. I don't think there are major differences, at least according to the linux driver.

Hope we can get this code merged, I think it would help a few users.
It was a fun little project.