### PR TITLE
Minimal support for Official Wireless USB Adapter

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -147,6 +147,13 @@ pub fn controllers() -> Result<Vec<Controller>> {
 
                 controllers.push(controller);
             }
+            (playstation::DS_VENDOR_ID, playstation::DS4_ADAPTER_PRODUCT_ID) => {
+                debug!("Found new DualShock 4 controller: {:?}", device_info);
+                let controller =
+                    playstation::parse_dualshock_controller_data(device_info, &hidapi)?;
+
+                controllers.push(controller);
+            }
             (playstation::DS_VENDOR_ID, playstation::DS4_NEW_PRODUCT_ID) => {
                 debug!("Found new DualShock 4 controller: {:?}", device_info);
                 let controller =

--- a/backend/src/api/playstation.rs
+++ b/backend/src/api/playstation.rs
@@ -16,7 +16,7 @@ pub const DS_VENDOR_ID: u16 = 0x054c;
 pub const DS4_OLD_PRODUCT_ID: u16 = 0x05c4;
 // Dualshock4 product ID changed after playstation update 5.50
 pub const DS4_NEW_PRODUCT_ID: u16 = 0x09cc;
-// Dualshock4 product ID for the official Wireless USB Adatper
+// Dualshock4 product ID for the official Wireless USB Adapter
 pub const DS4_ADAPTER_PRODUCT_ID: u16 = 0x0ba0;
 
 const DS4_INPUT_REPORT_USB: u8 = 0x01;

--- a/backend/src/api/playstation.rs
+++ b/backend/src/api/playstation.rs
@@ -16,6 +16,8 @@ pub const DS_VENDOR_ID: u16 = 0x054c;
 pub const DS4_OLD_PRODUCT_ID: u16 = 0x05c4;
 // Dualshock4 product ID changed after playstation update 5.50
 pub const DS4_NEW_PRODUCT_ID: u16 = 0x09cc;
+// Dualshock4 product ID for the official Wireless USB Adatper
+pub const DS4_ADAPTER_PRODUCT_ID: u16 = 0x0ba0;
 
 const DS4_INPUT_REPORT_USB: u8 = 0x01;
 const DS4_INPUT_REPORT_USB_SIZE: usize = 64;


### PR DESCRIPTION
Adds the code blocks needed to get the official Wireless USB Adapter working. Built via the action provided in the repo. Sideloading the backend executable over the currently available plugin from the Decky Stock to test the changes shows that the adapter is being detected properly.

When first connecting the adapter, Controller Tools shows the battery is at 5% (with no controller connected to the adapter). Upon connected a controller and refreshing the list of controllers, battery appears as it's current value. Disconnecting the controller (but not the adapter) will retain its last battery level detected. Not sure how you want to handle that, I'm not super familiar with rust to be implementing a "NC" flag for disconnected controllers with the adapter.